### PR TITLE
fix: create latest on master only

### DIFF
--- a/scripts/buildapp.py
+++ b/scripts/buildapp.py
@@ -64,7 +64,7 @@ if not ci_commit_branch:
     exit(1)
 
 # create a tag
-if ci_commit_branch == "dev":
+if ci_commit_branch != "master":
   tag = f"-{ci_commit_branch}"
 else:
   tag = ''

--- a/scripts/buildbaseimage.py
+++ b/scripts/buildbaseimage.py
@@ -59,7 +59,7 @@ if not ci_commit_branch:
     exit(1)
 
 # create a tag
-if ci_commit_branch == "dev":
+if ci_commit_branch != "master":
   tag = f"-{ci_commit_branch}"
 else:
   tag = ''

--- a/scripts/buildserver.py
+++ b/scripts/buildserver.py
@@ -43,7 +43,7 @@ if not ci_commit_branch:
     exit(1)
 
 # create a tag
-if ci_commit_branch == "dev":
+if ci_commit_branch != "master":
   tag = f"-{ci_commit_branch}"
 else:
   tag = ''


### PR DESCRIPTION
My test branches were all producing `:latest` because of this.

https://gitlab.hbp.link/hip/app-in-browser/-/pipelines/1649 redid the proper images from master.