### PR TITLE
chore: bump FSL from 6.7.0.9 to 6.7.0.11 

### DIFF
--- a/hip.yml
+++ b/hip.yml
@@ -99,9 +99,9 @@ apps:
 
   fsl:
     name: "FSL"
-    version: 6.0.7.9
-    url: "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSL"
-    description: "FSL is a comprehensive library of analysis tools for FMRI, MRI and DTI brain imaging data."
+    version: 6.0.7.11
+    url: "https://fsl.fmrib.ox.ac.uk/fsl/docs/#/"
+    description: "FSL is a comprehensive library of analysis tools for FMRI, MRI, and diffusion brain imaging data."
     state: ready
 
   gardel:


### PR DESCRIPTION
https://fsl.fmrib.ox.ac.uk/fsl/docs/#/development/history/index

- [x] https://github.com/HIP-infrastructure/fsl/pull/9