### PR TITLE
fix: GhostFS version like on master

### DIFF
--- a/hip.yml
+++ b/hip.yml
@@ -250,7 +250,7 @@ base:
 
   ghostfs:
     name: "GhostFS"
-    version: c7fcbab
+    version: c296342
     state: ready
 
   davfs2:


### PR DESCRIPTION
master has a more recent one than dev, cf https://github.com/HIP-infrastructure/app-in-browser/commit/611ebfe88e314cdbdb45e5f6df796c8489f0b547#diff-42c915b0665b042a227331670f4cea4eaa7269ba2dc907b647399970e4060d2f