### PR TITLE
fix: build base images requires buildx

### DIFF
--- a/.github/workflows/gitlab-sync.yml
+++ b/.github/workflows/gitlab-sync.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - dev
+      - fix-base-images
 jobs:
   git-sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/gitlab-sync.yml
+++ b/.github/workflows/gitlab-sync.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - master
       - dev
-      - fix-base-images
 jobs:
   git-sync:
     runs-on: ubuntu-latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,7 +39,6 @@ build-all-job:
   only:
     - master
     - dev
-    - fix-base-images
   script:
     - /bin/bash -c "python3 scripts/buildall.py"
   interruptible: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,14 +1,14 @@
-image: docker:20
+image: docker:27
 variables:
   # using "docker" as the host is only possible if you alias the service below
-  DOCKER_HOST: tcp://docker:2375 
+  DOCKER_HOST: tcp://docker:2375
   # could be wrong here but although Docker defaults to overlay2, 
   # Docker-in-Docker (DIND) does not according to the following GitLab doc: 
   # https://docs.gitlab.com/ee/ci/docker/using_docker_build.html#use-the-overlayfs-driver
   DOCKER_DRIVER: overlay2
   DOCKER_TLS_CERTDIR: ""
 services:
-  - name: docker:20-dind
+  - name: docker:27-dind
     alias: docker
     # in our experience although you'd assume this would be sufficient, this did 
     # nothing to prevent connection errors without `DOCKER_TLS_CERTDIR` being set 
@@ -27,7 +27,7 @@ before_script:
   - chmod 700 ~/.ssh
   - ssh-keyscan -H github.com >> ~/.ssh/known_hosts
   - git submodule init
-  - git submodule update 
+  - git submodule update
   - ./build/submodule_branch.sh $CI_COMMIT_BRANCH
   - echo $CI_REGISTRY_PASSWORD | docker login $CI_REGISTRY -u $CI_REGISTRY_USER --password-stdin
 
@@ -38,6 +38,7 @@ build-all-job:
   only:
     - master
     - dev
+    - fix-base-images
   script:
     - /bin/bash -c "python3 scripts/buildall.py"
   interruptible: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,8 @@ before_script:
   - apk add --no-cache git
   - apk add --no-cache python3
   - apk add --no-cache py3-pip
-  - pip3 install -r build/requirements.txt
+  - apk add --no-cache py3-yaml
+  - apk add --no-cache py3-dotenv
   - eval $(ssh-agent -s)
   - echo "$GITHUB_SSH_PRIVATE_KEY" | tr -d '\r' | ssh-add -
   - mkdir -p ~/.ssh

--- a/scripts/buildbaseimage.py
+++ b/scripts/buildbaseimage.py
@@ -97,20 +97,20 @@ for index, ver in enumerate(version):
       print(f"Failed pulling {registry_image} from registry.")
 
   #build base image with cache from registry during CI only
-  ret_val = subprocess.check_call(["docker", "build", "--build-arg", f"CI_REGISTRY_IMAGE={ci_registry_image}", \
-                                                      "--build-arg", f"VERSION={ver}", \
-                                                      "--build-arg", f"UPDATE={update}", \
-                                                      "--build-arg", f"TAG={tag}", \
-                                                      "--build-arg", f"VIRTUALGL_VERSION={virtualgl_version}", \
-                                                      "--build-arg", f"TERMINAL_VERSION={terminal_version}", \
-                                                      "--build-arg", f"DOCKERFS_VERSION={dockerfs_version}", \
-                                                      "--build-arg", f"DOCKERFS_TYPE={dockerfs_type}", \
-                                                      *(["--cache-from", registry_image] if ci_registry else []),
-                                                      *(["--progress=plain"] if ci_registry else []),
-                                                      "-t", registry_image, \
-                                                      "-f", f"{context}/base-images/{name}/{dockerfile}", \
-                                                      context])
-  assert ret_val == 0, f"Failed building {name}."
+  subprocess.check_call(["docker", "buildx", "build", \
+                                   "--build-arg", f"CI_REGISTRY_IMAGE={ci_registry_image}", \
+                                   "--build-arg", f"VERSION={ver}", \
+                                   "--build-arg", f"UPDATE={update}", \
+                                   "--build-arg", f"TAG={tag}", \
+                                   "--build-arg", f"VIRTUALGL_VERSION={virtualgl_version}", \
+                                   "--build-arg", f"TERMINAL_VERSION={terminal_version}", \
+                                   "--build-arg", f"DOCKERFS_VERSION={dockerfs_version}", \
+                                   "--build-arg", f"DOCKERFS_TYPE={dockerfs_type}", \
+                                   *(["--cache-from", registry_image] if ci_registry else []),
+                                   *(["--progress=plain"] if ci_registry else []),
+                                   "-t", registry_image, \
+                                   "-f", f"{context}/base-images/{name}/{dockerfile}", \
+                                   context])
 
   #push the base image to registry during CI only
   if ci_registry:


### PR DESCRIPTION
> Step 9/11 : RUN --mount=type=cache,target=/var/cache/apt,sharing=locked     --mount=type=cache,target=/var/lib/apt,sharing=locked     apt-get update -q &&     apt-get upgrade -qy &&     apt-get install --no-install-recommends -y         curl ca-certificates libglu1-mesa libegl1-mesa libxv1 libxtst6 libegl-mesa0 primus gpg &&     curl -fsSL https://packagecloud.io/dcommander/virtualgl/gpgkey |         gpg --yes --dearmor -o /usr/share/keyrings/virtualgl.gpg &&     echo 'deb [signed-by=/usr/share/keyrings/virtualgl.gpg] https://packagecloud.io/dcommander/virtualgl/any/ any main' |         tee /etc/apt/sources.list.d/virtualgl.list &&     apt-get update -q &&     version=$(apt-cache madison virtualgl | grep -o "${VERSION}-[0-9]*") &&     apt-get install --no-install-recommends -y         virtualgl=${version} &&     apt-get remove -y --purge curl gpg &&     apt-get autoremove -y --purge
the --mount option requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled