### PR TITLE
fix(server): Xpra needs xpra-x11

### DIFF
--- a/services/server/Dockerfile.ubuntu-main
+++ b/services/server/Dockerfile.ubuntu-main
@@ -35,7 +35,8 @@ RUN apt-get update && \
     curl -sSL https://xpra.org/gpg.asc | apt-key add - && \
     add-apt-repository "deb https://xpra.org/ jammy main" && \
     apt-get update && \
-    apt-get install --no-install-recommends -y xpra xpra-html5 && \
+    apt-get install --no-install-recommends -y \
+    xpra xpra-html5 xpra-x11 && \
     apt-get remove -y --purge gnupg && \
     apt-get autoremove -y --purge && \
     apt-get clean && \
@@ -45,17 +46,17 @@ RUN apt-get update && \
     echo "\nclass-instance:vglrun=video" >> /etc/xpra/content-type/50_class.conf && \
     # create the xpra user and socket directory
     useradd --create-home --shell /bin/bash xpra --gid xpra --uid 1000 && \
-    mkdir -p /run/user/1000/xpra && \
-    chown -R 1000 /run/user/1000 && \
+    mkdir -p /run/user/1000/xpra /home/xpra/.xpra && \
+    chown -R 1000 /run/user/1000 /home/xpra/.xpra && \
     chmod -R 700 /run/user/1000
 
 HEALTHCHECK --interval=10s --timeout=10s --retries=5 --start-period=30s \
-  CMD curl -fks https://localhost:8080
+  CMD curl -fs http://localhost:8080
 
 WORKDIR /home/xpra
 
 # copy xpra config files
-COPY server/config/xpra.conf /etc/xpra/xpra.conf
+COPY server/config/xpra.conf /home/xpra/.xpra/xpra.conf
 COPY server/config/10_content_security_policy.txt /etc/xpra/http-headers/10_content_security_policy.txt
 COPY server/config/default.png /usr/share/backgrounds/images/default.png
 COPY server/config/default-settings.txt /etc/xpra/html5-client/default-settings.txt


### PR DESCRIPTION
This is the version currently in dev (more or less).

Use `docker exec ... runuser xpra -c 'xpra showconfig'` to validate that xpra.config is properly loaded. I cannot make the _clipboard_ button disappear.

💯 
