### PR TITLE
fix(apps): jupyterlab version to match base image

### DIFF
--- a/hip.yml
+++ b/hip.yml
@@ -127,7 +127,7 @@ apps:
 
   jupyterlab:
     name: "JupyterLab Desktop"
-    version: latest
+    version: 4.2.5-1
     url: "https://github.com/jupyterlab/jupyterlab-desktop"
     description: "JupyterLab Desktop is the cross-platform desktop application for JupyterLab and the quickest and easiest way to get started with Jupyter notebooks on your personal computer."
     state: beta


### PR DESCRIPTION
So we the get right information in the UI. Latest doesn't mean anything.