### PR TITLE
fix: xpra-server 6.2 has moved its cert

### DIFF
--- a/services/server/Dockerfile.ubuntu-main
+++ b/services/server/Dockerfile.ubuntu-main
@@ -36,12 +36,12 @@ RUN apt-get update && \
     add-apt-repository "deb https://xpra.org/ jammy main" && \
     apt-get update && \
     apt-get install --no-install-recommends -y \
-    xpra xpra-html5 xpra-x11 && \
+    xpra xpra-html5 xpra-server xpra-x11 && \
     apt-get remove -y --purge gnupg && \
     apt-get autoremove -y --purge && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    chmod 644 /etc/xpra/ssl-cert.pem && \
+    chmod 644 /etc/xpra/ssl/cert.pem && \
     # make all applications started with vglrun use video stream encoding
     echo "\nclass-instance:vglrun=video" >> /etc/xpra/content-type/50_class.conf && \
     # create the xpra user and socket directory


### PR DESCRIPTION
It's not building as is

![Screenshot 2024-10-16 at 12-01-47 build-all-job (#3160) · Jobs · HIP _ app-in-browser · GitLab](https://github.com/user-attachments/assets/b32542d5-73ee-45cb-93f2-ee1b5b89f88c)
